### PR TITLE
[Linux] Adjust path to glslangvalidator on non windows platforms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ target_link_libraries(niagara
     meshoptimizer)
 
 if(UNIX)
-  set(GLSL_VALIDATOR "glslangValidator")
+  set(GLSL_VALIDATOR "$ENV{VULKAN_SDK}/bin/glslangValidator")
 elseif(${CMAKE_HOST_SYSTEM_PROCESSOR} STREQUAL "AMD64")
   set(GLSL_VALIDATOR "$ENV{VULKAN_SDK}/Bin/glslangValidator.exe")
 else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,11 @@ target_link_libraries(niagara
     meshoptimizer)
 
 if(UNIX)
-  set(GLSL_VALIDATOR "$ENV{VULKAN_SDK}/bin/glslangValidator")
+  if(DEFINED ENV{VULKAN_SDK})
+    set(GLSL_VALIDATOR "$ENV{VULKAN_SDK}/bin/glslangValidator")
+  else()
+    set(GLSL_VALIDATOR "glslangValidator")
+  endif()
 elseif(${CMAKE_HOST_SYSTEM_PROCESSOR} STREQUAL "AMD64")
   set(GLSL_VALIDATOR "$ENV{VULKAN_SDK}/Bin/glslangValidator.exe")
 else()


### PR DESCRIPTION
Hi Arseny,

cmake was not able to find glslangValidator, but with this change it will.

Tested on archlinux.