### PR TITLE
adding missing files to solution to fix compile error on windows.

### DIFF
--- a/src/niagara.vcxproj
+++ b/src/niagara.vcxproj
@@ -249,6 +249,7 @@
     <ClCompile Include="..\extern\meshoptimizer\src\indexgenerator.cpp" />
     <ClCompile Include="..\extern\meshoptimizer\src\overdrawanalyzer.cpp" />
     <ClCompile Include="..\extern\meshoptimizer\src\overdrawoptimizer.cpp" />
+    <ClCompile Include="..\extern\meshoptimizer\src\quantization.cpp" />
     <ClCompile Include="..\extern\meshoptimizer\src\simplifier.cpp" />
     <ClCompile Include="..\extern\meshoptimizer\src\spatialorder.cpp" />
     <ClCompile Include="..\extern\meshoptimizer\src\stripifier.cpp" />

--- a/src/niagara.vcxproj.filters
+++ b/src/niagara.vcxproj.filters
@@ -170,6 +170,9 @@
     <ClCompile Include="..\extern\glfw\src\null_window.c">
       <Filter>glfw</Filter>
     </ClCompile>
+    <ClCompile Include="..\extern\meshoptimizer\src\quantization.cpp">
+      <Filter>meshoptimizer</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <CustomBuild Include="shaders\meshlet.mesh.glsl">


### PR DESCRIPTION
The included Visual Studio solution does not build after meshopt was updated.

I've manually added the missing file. now the project builds when you follow the directions on the readme.