### PR TITLE
Add missing <cstring> include

### DIFF
--- a/src/scene.cpp
+++ b/src/scene.cpp
@@ -11,6 +11,7 @@
 
 #include <algorithm>
 #include <memory>
+#include <cstring>
 
 static size_t appendMeshlets(Geometry& result, const std::vector<Vertex>& vertices, const std::vector<uint32_t>& indices, bool fast = false)
 {


### PR DESCRIPTION
Hey, zeux

I'm in search of vulkan renderers for learn how to create a good drawing API.
I'm going to explore your project a bit.

So, I met issue with compilation on linux - missing <cstring> include in *scene.cpp*

I've used *g++* as compiler and *libstdc++* as STL.

I didn't tested this fix on windows, but it shouldn't break anything.
Probably add few github actions workflow is a good idea.

I also found much more compilation errors on linux using *clang++*. Most of them due to `-Werror` and `-Wc++98-compat`. I don't know if you care about this. That's why I didn't fix them