### PR TITLE
fixes a vulkan validation error , VUID-vkDestroyInstance-instance-00629

### DIFF
--- a/src/niagara.cpp
+++ b/src/niagara.cpp
@@ -359,6 +359,8 @@ int main(int argc, const char** argv)
 	VkPhysicalDevice physicalDevice = pickPhysicalDevice(physicalDevices, physicalDeviceCount);
 	if (!physicalDevice)
 	{
+		if (debugCallback) 
+		vkDestroyDebugReportCallbackEXT(instance, debugCallback, 0);
 		vkDestroyInstance(instance, 0);
 		return -1;
 	}


### PR DESCRIPTION
well i got the error so i fixed it ,
```
./niagara list
Enabled Vulkan validation layers (sync validation disabled)
GPU0: Intel(R) UHD Graphics (TGL GT2) (Vulkan 1.3)
ERROR: No compatible GPU found
ERROR: Validation Error: [ VUID-vkDestroyInstance-instance-00629 ] Object 0: handle = 0x62deab6327f0, type = VK_OBJECT_TYPE_INSTANCE; Object 1: handle = 0xfd5b260000000001, type = VK_OBJECT_TYPE_DEBUG_REPORT_CALLBACK_EXT; | MessageID = 0x8b3d8e18 | vkDestroyInstance():  OBJ ERROR : For VkInstance 0x62deab6327f0[], VkDebugReportCallbackEXT 0xfd5b260000000001[] has not been destroyed.
The Vulkan spec states: All child objects created using instance must have been destroyed prior to destroying instance (https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VUID-vkDestroyInstance-instance-00629)
niagara: /home/lka/practice/mygames/niagara/src/device.cpp:142: VkBool32 debugReportCallback(VkDebugReportFlagsEXT, VkDebugReportObjectTypeEXT, uint64_t, size_t, int32_t, const char*, const char*, void*): Assertion `!"Validation error encountered!"' failed.
```