### PR TITLE
Load scene before window creation

### DIFF
--- a/src/niagara.cpp
+++ b/src/niagara.cpp
@@ -248,6 +248,10 @@ void keyCallback(GLFWwindow* window, int key, int scancode, int action, int mods
 		{
 			debugSleep = !debugSleep;
 		}
+		if (key == GLFW_KEY_ESCAPE)
+		{
+			glfwSetWindowShouldClose(window, true);
+		}
 	}
 }
 

--- a/src/niagara.cpp
+++ b/src/niagara.cpp
@@ -404,22 +404,6 @@ int main(int argc, const char** argv)
 
 	volkLoadDevice(device);
 
-	GLFWwindow* window = glfwCreateWindow(1024, 768, "niagara", 0, 0);
-	assert(window);
-
-	glfwSetKeyCallback(window, keyCallback);
-	glfwSetMouseButtonCallback(window, mouseCallback);
-
-	VkSurfaceKHR surface = createSurface(instance, window);
-	assert(surface);
-
-	VkBool32 presentSupported = 0;
-	VK_CHECK(vkGetPhysicalDeviceSurfaceSupportKHR(physicalDevice, familyIndex, surface, &presentSupported));
-	assert(presentSupported);
-
-	VkFormat swapchainFormat = getSwapchainFormat(physicalDevice, surface);
-	VkFormat depthFormat = VK_FORMAT_D32_SFLOAT;
-
 	VkSemaphore acquireSemaphores[MAX_FRAMES] = {};
 	VkFence frameFences[MAX_FRAMES] = {};
 
@@ -441,6 +425,8 @@ int main(int argc, const char** argv)
 
 	VkSampler depthSampler = createSampler(device, VK_FILTER_LINEAR, VK_SAMPLER_MIPMAP_MODE_NEAREST, VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE, VK_SAMPLER_REDUCTION_MODE_MIN);
 	assert(depthSampler);
+
+	VkFormat depthFormat = VK_FORMAT_D32_SFLOAT;
 
 	static const size_t gbufferCount = 2;
 	const VkFormat gbufferFormats[gbufferCount] = {
@@ -570,17 +556,6 @@ int main(int argc, const char** argv)
 
 	createPipelines();
 
-	Swapchain swapchain;
-	createSwapchain(swapchain, physicalDevice, device, surface, familyIndex, window, swapchainFormat);
-
-	std::vector<VkSemaphore> presentSemaphores(swapchain.imageCount);
-
-	for (uint32_t i = 0; i < swapchain.imageCount; ++i)
-	{
-		presentSemaphores[i] = createSemaphore(device);
-		assert(presentSemaphores[i]);
-	}
-
 	VkQueryPool queryPoolsTimestamp[MAX_FRAMES] = {};
 	VkQueryPool queryPoolsPipeline[MAX_FRAMES] = {};
 
@@ -640,6 +615,7 @@ int main(int argc, const char** argv)
 		const char* ext = strrchr(argv[1], '.');
 		if (ext && (strcmp(ext, ".gltf") == 0 || strcmp(ext, ".glb") == 0))
 		{
+			printf("Loading scene from %s\n", argv[1]);
 			if (!loadScene(geometry, materials, draws, texturePaths, animations, camera, sunDirection, argv[1], meshShadingSupported, fastMode, clrtMode))
 			{
 				printf("Error: scene %s failed to load\n", argv[1]);
@@ -907,6 +883,32 @@ int main(int argc, const char** argv)
 	uint32_t depthPyramidWidth = 0;
 	uint32_t depthPyramidHeight = 0;
 	uint32_t depthPyramidLevels = 0;
+
+	GLFWwindow* window = glfwCreateWindow(1024, 768, "niagara", 0, 0);
+	assert(window);
+
+	glfwSetKeyCallback(window, keyCallback);
+	glfwSetMouseButtonCallback(window, mouseCallback);
+
+	VkSurfaceKHR surface = createSurface(instance, window);
+	assert(surface);
+
+	VkBool32 presentSupported = 0;
+	VK_CHECK(vkGetPhysicalDeviceSurfaceSupportKHR(physicalDevice, familyIndex, surface, &presentSupported));
+	assert(presentSupported);
+
+	VkFormat swapchainFormat = getSwapchainFormat(physicalDevice, surface);
+
+	Swapchain swapchain;
+	createSwapchain(swapchain, physicalDevice, device, surface, familyIndex, window, swapchainFormat);
+
+	std::vector<VkSemaphore> presentSemaphores(swapchain.imageCount);
+
+	for (uint32_t i = 0; i < swapchain.imageCount; ++i)
+	{
+		presentSemaphores[i] = createSemaphore(device);
+		assert(presentSemaphores[i]);
+	}
 
 	std::vector<VkImageView> swapchainImageViews(swapchain.imageCount);
 


### PR DESCRIPTION
This moves the scene loading code to run before window-creation, adds printing of a "loading ..." string to the console, and allows us to push ESC to exit.

The purpose of moving the load is to work around the issue of the code not pumping events during a long load, which can introduce a warning from the DE/window manager.

<img width="1030" height="766" alt="Screenshot from 2025-09-01 01-30-32 - Niagara not responding" src="https://github.com/user-attachments/assets/1e0fd1e7-94a8-4ac2-b90e-2f9975355a00" />

On my system even a `FAST=1` (which takes ~7.5s) is long enough to trigger this. I'm guessing the cutoff is 5s.

```console
Enabled Vulkan validation layers (sync validation disabled)
WARNING: radv is not a conformant Vulkan implementation, testing use only.
GPU0: AMD Radeon Graphics (RADV GFX1201) (Vulkan 1.4)
Selected GPU AMD Radeon Graphics (RADV GFX1201)
Loading scene from ../niagara_bistro/bistro.gltf
Loaded ../niagara_bistro/bistro.gltf: 551 meshes, 2909 draws, 0 animations, 1672766 vertices in 7.50 sec
Meshlets: 77165 meshlets, 4275738 triangles, 4827061 vertex refs
Loaded 14 shaders from ./build/spirv/
Loaded 343 textures (2114.06 MB) in 0.36 sec
Geometry: VB 26.76 MB, IB 51.31 MB, meshlets 25.08 MB
BLAS accelerationStructureSize: 470.04 MB, scratchSize: 33.55 MB (max 15.27 MB), 1.754M triangles
BLAS compacted accelerationStructureSize: 312.54 MB
TLAS accelerationStructureSize: 1.16 MB, scratchSize: 0.46 MB, updateScratch: 0.46 MB
Swapchain: 1024x768
```