### PR TITLE
Replace manual surface extension setup.

### DIFF
--- a/src/device.cpp
+++ b/src/device.cpp
@@ -7,6 +7,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <GLFW/glfw3.h>
+
 // Validation is enabled by default in Debug
 #ifndef NDEBUG
 #define KHR_VALIDATION 1
@@ -98,22 +100,14 @@ VkInstance createInstance()
 #endif
 
 	std::vector<const char*> extensions;
-	extensions.push_back(VK_KHR_SURFACE_EXTENSION_NAME);
-#ifdef VK_USE_PLATFORM_WIN32_KHR
-	extensions.push_back(VK_KHR_WIN32_SURFACE_EXTENSION_NAME);
-#endif
-#ifdef VK_USE_PLATFORM_XLIB_KHR
-	if (isInstanceExtensionSupported(VK_KHR_XLIB_SURFACE_EXTENSION_NAME))
-		extensions.push_back(VK_KHR_XLIB_SURFACE_EXTENSION_NAME);
-#endif
-#ifdef VK_USE_PLATFORM_WAYLAND_KHR
-	if (isInstanceExtensionSupported(VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME))
-		extensions.push_back(VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME);
-#endif
-#ifdef VK_USE_PLATFORM_METAL_EXT
-	extensions.push_back(VK_EXT_METAL_SURFACE_EXTENSION_NAME);
-	extensions.push_back(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME);
-#endif
+
+	// Query Vulkan instance extensions required by GLFW for creating Vulkan surfaces for GLFW windows.
+	uint32_t instanceCount;
+	const char** reqInstanceExtensions = glfwGetRequiredInstanceExtensions(&instanceCount);
+	if (instanceCount) {
+		extensions.assign(reqInstanceExtensions, reqInstanceExtensions + instanceCount);
+	}
+
 #ifndef NDEBUG
 	extensions.push_back(VK_EXT_DEBUG_REPORT_EXTENSION_NAME);
 #endif


### PR DESCRIPTION
After the switch to `glfwCreateWindowSurface`, the code crashes with my wayland-less GLFW build, because the compile time defines doesn't match the reality of the runtime.

```console
niagara: .../niagara/src/swapchain.cpp:28: VkSurfaceKHR_T* createSurface(VkInstance, GLFWwindow*): Assertion `result_ == VK_SUCCESS' failed.
```

The return value is `VK_ERROR_EXTENSION_NOT_PRESENT` (-7)

Should perhaps be tested on Win/Mac before merge, but I think this is conceptually the correct way to do this.

I think for linux at least, it makes more sense to rely on runtime `glfwPlatformSupported()` checks over compile-time ifdefs, but I leave that open.

EDIT: There's a warning in the [docs](https://www.glfw.org/docs/3.3/vulkan_guide.html#vulkan_ext) about MoltenVK, not sure if it's still relevant.

> macOS: MoltenVK is (as of July 2022) not yet a fully conformant implementation of Vulkan. As of Vulkan SDK 1.3.216.0, this means you must also enable the VK_KHR_portability_enumeration instance extension and set the VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR bit in the instance creation info flags for MoltenVK to show up in the list of physical devices. For more information, see the Vulkan and MoltenVK documentation.
