### PR TITLE
Compress meshlet data using new meshletcodec

### DIFF
--- a/src/scene.cpp
+++ b/src/scene.cpp
@@ -67,8 +67,10 @@ static void appendMeshlet(Geometry& result, const meshopt_Meshlet& meshlet, cons
 	m.vertexCount = meshlet.vertex_count;
 	m.shortRefs = shortRefs;
 
-	m.center = vec3(bounds.center[0], bounds.center[1], bounds.center[2]);
-	m.radius = bounds.radius;
+	m.center[0] = meshopt_quantizeHalf(bounds.center[0]);
+	m.center[1] = meshopt_quantizeHalf(bounds.center[1]);
+	m.center[2] = meshopt_quantizeHalf(bounds.center[2]);
+	m.radius = meshopt_quantizeHalf(bounds.radius);
 	m.cone_axis[0] = bounds.cone_axis_s8[0];
 	m.cone_axis[1] = bounds.cone_axis_s8[1];
 	m.cone_axis[2] = bounds.cone_axis_s8[2];

--- a/src/scene.h
+++ b/src/scene.h
@@ -7,10 +7,10 @@
 #include <string>
 #include <vector>
 
-struct alignas(16) Meshlet
+struct alignas(8) Meshlet
 {
-	vec3 center;
-	float radius;
+	uint16_t center[3];
+	uint16_t radius;
 	int8_t cone_axis[3];
 	int8_t cone_cutoff;
 

--- a/src/shaders/clustercull.comp.glsl
+++ b/src/shaders/clustercull.comp.glsl
@@ -67,10 +67,11 @@ void main()
 	uint mvi = mgi + command.meshletVisibilityOffset;
 
 #if CULL
-	vec3 center = rotateQuat(meshlets[mi].center, meshDraw.orientation) * meshDraw.scale + meshDraw.position;
+	vec3 center = vec3(meshlets[mi].center[0], meshlets[mi].center[1], meshlets[mi].center[2]);
+	center = rotateQuat(center, meshDraw.orientation) * meshDraw.scale + meshDraw.position;
 	center = (cullData.view * vec4(center, 1)).xyz;
 
-	float radius = meshlets[mi].radius * meshDraw.scale;
+	float radius = float(meshlets[mi].radius) * meshDraw.scale;
 
 	vec3 cone_axis = rotateQuat(vec3(int(meshlets[mi].cone_axis[0]) / 127.0, int(meshlets[mi].cone_axis[1]) / 127.0, int(meshlets[mi].cone_axis[2]) / 127.0), meshDraw.orientation);
 	cone_axis = mat3(cullData.view) * cone_axis;

--- a/src/shaders/mesh.h
+++ b/src/shaders/mesh.h
@@ -10,9 +10,8 @@ struct Vertex
 
 struct Meshlet
 {
-	// vec3 keeps Meshlet aligned to 16 bytes which is important because C++ has an alignas() directive
-	vec3 center;
-	float radius;
+	float16_t center[3];
+	float16_t radius;
 	int8_t cone_axis[3];
 	int8_t cone_cutoff;
 
@@ -21,6 +20,7 @@ struct Meshlet
 	uint8_t vertexCount;
 	uint8_t triangleCount;
 	uint8_t shortRefs;
+	uint8_t padding;
 };
 
 struct CullData

--- a/src/shaders/meshlet.task.glsl
+++ b/src/shaders/meshlet.task.glsl
@@ -69,10 +69,11 @@ void main()
 
 	CullData cullData = globals.cullData;
 
-	vec3 center = rotateQuat(meshlets[mi].center, meshDraw.orientation) * meshDraw.scale + meshDraw.position;
+	vec3 center = vec3(meshlets[mi].center[0], meshlets[mi].center[1], meshlets[mi].center[2]);
+	center = rotateQuat(center, meshDraw.orientation) * meshDraw.scale + meshDraw.position;
 	center = (cullData.view * vec4(center, 1)).xyz;
 
-	float radius = meshlets[mi].radius * meshDraw.scale;
+	float radius = float(meshlets[mi].radius) * meshDraw.scale;
 	vec3 cone_axis = rotateQuat(vec3(int(meshlets[mi].cone_axis[0]) / 127.0, int(meshlets[mi].cone_axis[1]) / 127.0, int(meshlets[mi].cone_axis[2]) / 127.0), meshDraw.orientation);
 	cone_axis = mat3(cullData.view) * cone_axis;
 


### PR DESCRIPTION
This change integrates new meshletcodec from meshoptimizer to compress meshlet data, resulting in 2.5-3x compression depending on the file. It decompresses at 8-9 GB/s, well above vertex or index codecs.

Since meshlet headers were starting to look a little too large in relation to the meshlet data, this also converts the bounding sphere to use float16 - since we now use halfs to store vertex positions, they should be sufficient here too. (ideally the bounding sphere radius may need to be adjusted upwards to stay conservative but this is probably good enough as is)

bistro.gltf+bin: 100.4 MB
bistro.gltf.cache, uncompressed: ~111 MB <sup>(38.1 MB zstd)</sup>
bistro.gltf.cache, before: 51.9 MB <sup>(27.7 MB zstd)</sup>
bistro.gltf.cache, after: 38.2 MB <sup>(23.5 MB zstd)</sup>

(this is too simple to do on stream and doesn't naturally fold into any upcoming topics so I figured I could just do this offline and submit a PR)